### PR TITLE
Remove push trigger from e2e workflows

### DIFF
--- a/.github/workflows/scorecards-head.yml
+++ b/.github/workflows/scorecards-head.yml
@@ -5,8 +5,6 @@ on:
   branch_protection_rule:
   schedule:
     - cron: '0 2 * * *'
-  push:
-    branches: [ main ]
 
 # Declare default permissions as read only.
 

--- a/.github/workflows/scorecards-latest-release.yml
+++ b/.github/workflows/scorecards-latest-release.yml
@@ -5,8 +5,6 @@ on:
   branch_protection_rule:
   schedule:
     - cron: '0 0 * * *'
-  push:
-    branches: [ main ]
 
 # Declare default permissions as read only.
 


### PR DESCRIPTION
Looking at the runs:

https://github.com/ossf-tests/scorecard-action/actions/workflows/scorecards-head.yml
https://github.com/ossf-tests/scorecard-action/actions/workflows/scorecards-latest-release.yml

Each fork sync kicks off 4 workflow runs at the same time, 2 of head and 2 of latest. This is causing API rate limiting lead to a lot of failures:
https://github.com/ossf/scorecard-action/issues/1220
https://github.com/ossf/scorecard-action/issues/1219

This removes the `push` triggers (which run once a day), but the workflows still runs daily from the cron trigger, so we're not losing any testing frequency.