### PR TITLE
Switch `gh auth` to default github token.

### DIFF
--- a/.github/workflows/auto-sync-fork.yml
+++ b/.github/workflows/auto-sync-fork.yml
@@ -10,12 +10,14 @@ jobs:
   auto-sync-fork:
     name: Sync fork
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: "gh repo sync"
         id: gh-repo-sync
         run: gh repo sync ${{ github.repository }} -b main
         env:
-          GITHUB_TOKEN: ${{ secrets.SCORECARD_READ_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
       - name: "report failure"
         if: always() && steps.gh-repo-sync.outcome != 'success'
         uses: actions-ecosystem/action-create-issue@b02a3c1d9d929a5839315bd255e40389f0dab627 #v1


### PR DESCRIPTION
Not sure why this was changed, back in https://github.com/ossf-tests/scorecard-action/commit/9b7426be664969f677c8de5f21d8ba7f18597a20, but the workflow continues to have problems syncing.

Reverting the commit, following instructions at https://cli.github.com/manual/gh_auth_login

> To use gh in GitHub Actions, add GH_TOKEN: ${{ github.token }} to "env".