### PR TITLE
Update auto-sync-fork.yml to use PAT with workflow scope

### DIFF
--- a/.github/workflows/auto-sync-fork.yml
+++ b/.github/workflows/auto-sync-fork.yml
@@ -10,14 +10,14 @@ jobs:
   auto-sync-fork:
     name: Sync fork
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: "gh repo sync"
         id: gh-repo-sync
         run: gh repo sync ${{ github.repository }} -b main
         env:
-          GH_TOKEN: ${{ github.token }}
+          # PAT should have write access to "contents" and "workflows"
+          # https://github.com/cli/cli/issues/7574
+          GH_TOKEN: ${{ secrets.SYNC_TOKEN }}
       - name: "report failure"
         if: always() && steps.gh-repo-sync.outcome != 'success'
         uses: actions-ecosystem/action-create-issue@b02a3c1d9d929a5839315bd255e40389f0dab627 #v1


### PR DESCRIPTION
Follow up of #5, with the issue fixed. 

There was a recent change that began requiring [workflow scope](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/scopes-for-oauth-apps#available-scopes) on the token if any commits to be merged from upstream included workflow changes. This uses a fine-grained PAT of mine, limited to this repo, with `contents` and `workflows` permissions. It will expire in a year (2024/07/19)