### PR TITLE
bump action versions for e2e workflows

### DIFF
--- a/.github/workflows/scorecards-head.yml
+++ b/.github/workflows/scorecards-head.yml
@@ -34,7 +34,7 @@ jobs:
             upload_result: false
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           persist-credentials: false
       - name: "Run analysis"
@@ -57,7 +57,7 @@ jobs:
       # Upload the results as artifacts (optional).
       - name: "Upload artifact"
         if: steps.scorecard-run.outcome == 'success'
-        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: ${{ matrix.results_format }} file
           path: results.${{ matrix.results_format }}
@@ -65,7 +65,7 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
         if: matrix.upload_result == true && steps.scorecard-run.outcome == 'success'
-        uses: github/codeql-action/upload-sarif@5f532563584d71fdef14ee64d17bafb34f751ce5 # v1.0.26
+        uses: github/codeql-action/upload-sarif@74483a38d39275f33fcff5f35b679b5ca4a26a99 # v2.22.5
         with:
           sarif_file: results.sarif
   report-failure:

--- a/.github/workflows/scorecards-latest-release.yml
+++ b/.github/workflows/scorecards-latest-release.yml
@@ -34,7 +34,7 @@ jobs:
             upload_result: false
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           persist-credentials: false
       - name: "Run Scorecard analysis"
@@ -55,7 +55,7 @@ jobs:
       # Upload the results as artifacts (optional).
       - name: "Upload artifact"
         if: steps.scorecard-run.outcome == 'success'
-        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: ${{ matrix.results_format }} file
           path: results.${{ matrix.results_format }}
@@ -63,7 +63,7 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
         if: matrix.upload_result == true && steps.scorecard-run.outcome == 'success'
-        uses: github/codeql-action/upload-sarif@5f532563584d71fdef14ee64d17bafb34f751ce5 # v1.0.26
+        uses: github/codeql-action/upload-sarif@74483a38d39275f33fcff5f35b679b5ca4a26a99 # v2.22.5
         with:
           sarif_file: results.sarif
   report-failure:


### PR DESCRIPTION
We don't have dependabot enabled since the main repo does. However this causes these two files to not be updated. GitHub has been complaining about using deprecated set-output and save-state functionality, which happens indirectly through other actions.

https://github.com/ossf-tests/scorecard-action/actions/runs/6714914034

> The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

> The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579, actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2, github/codeql-action/upload-sarif@5f532563584d71fdef14ee64d17bafb34f751ce5. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
