### PR TITLE
remove testing of 'default' format

### DIFF
--- a/.github/workflows/scorecards-head.yml
+++ b/.github/workflows/scorecards-head.yml
@@ -22,15 +22,13 @@ jobs:
       max-parallel: 1
       fail-fast: false
       matrix:
-        results_format: [sarif, json, default]
+        results_format: [sarif, json]
         publish_results: [false, true]
         token: [ GITHUB_TOKEN, SCORECARD_READ_TOKEN ]
         include:
           - results_format: sarif
             upload_result: true
           - results_format: json
-            upload_result: false
-          - results_format: default
             upload_result: false
     steps:
       - name: "Checkout code"

--- a/.github/workflows/scorecards-latest-release.yml
+++ b/.github/workflows/scorecards-latest-release.yml
@@ -22,15 +22,13 @@ jobs:
       max-parallel: 1
       fail-fast: false
       matrix:
-        results_format: [sarif, json, default]
+        results_format: [sarif, json]
         publish_results: [false, true]
         token: [GITHUB_TOKEN, SCORECARD_READ_TOKEN]
         include:
           - results_format: sarif
             upload_result: true
           - results_format: json
-            upload_result: false
-          - results_format: default
             upload_result: false
     steps:
       - name: "Checkout code"


### PR DESCRIPTION
This was previously supported by Scorecard Action because it hooked the underlying Scorecard cobra entrypoint, which accepts `--format default`. However, this was removed from Scorecard Action's action.yaml before the first release and was never in the documentation.

https://github.com/ossf/scorecard-action/pull/16
https://github.com/ossf/scorecard-action/pull/31

Fixes https://github.com/ossf/scorecard-action/issues/1430
Fixes https://github.com/ossf/scorecard-action/issues/1431
Fixes https://github.com/ossf/scorecard-action/issues/1432
Fixes https://github.com/ossf/scorecard-action/issues/1433
Fixes https://github.com/ossf/scorecard-action/issues/1434
Fixes https://github.com/ossf/scorecard-action/issues/1435
Fixes https://github.com/ossf/scorecard-action/issues/1436