### PR TITLE
use GitHub Container Registry images for e2e tests

### DIFF
--- a/.github/workflows/scorecards-head.yml
+++ b/.github/workflows/scorecards-head.yml
@@ -37,7 +37,7 @@ jobs:
           persist-credentials: false
       - name: "Run analysis"
         id: scorecard-run
-        uses: docker://gcr.io/openssf/scorecard-action:latest
+        uses: docker://ghcr.io/ossf/scorecard-action:latest
         with:
           entrypoint: "/scorecard-action"
           results_file: results.${{ matrix.results_format }}


### PR DESCRIPTION
Follow up of https://github.com/ossf/scorecard-action/pull/1453 and https://github.com/ossf/scorecard-webapp/pull/707