### PR TITLE
use maintained GitHub action to create issues

### DIFF
--- a/.github/workflows/scorecards-head.yml
+++ b/.github/workflows/scorecards-head.yml
@@ -72,19 +72,22 @@ jobs:
     if: always() && needs.scorecard-head.result != 'success'
     steps:
       - name: "Report Scorecard run failure"
-        uses: actions-ecosystem/action-create-issue@b02a3c1d9d929a5839315bd255e40389f0dab627 #v1
-        with:
-          github_token: ${{ secrets.SCORECARD_READ_TOKEN }}
-          title: "Failing e2e tests - scorecard-head on ${{ github.repository }}"
-          body: |
-            Matrix: ${{ toJSON(matrix) }}
+        env:
+          ISSUE_BODY: |
             Repo: https://github.com/${{ github.repository }}/tree/${{ github.ref_name }}
             Run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
             Workflow name: ${{ github.workflow }}
             Workflow file: https://github.com/${{ github.repository }}/tree/main/.github/workflows/scorecards-head.yml
             Trigger: ${{ github.event_name }}
             Branch: ${{ github.ref_name }}
-          repo: "ossf/scorecard-action"
-          labels: |
-            e2e
-            automated-tests
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{ secrets.SCORECARD_READ_TOKEN }}
+          script: |
+            github.rest.issues.create({
+              owner: "ossf",
+              repo: "scorecard-action",
+              title: "Failing e2e tests - scorecard-head on ${{ github.repository }}",
+              body: process.env.ISSUE_BODY,
+              labels: ["e2e", "automated-tests"]
+            });

--- a/.github/workflows/scorecards-head.yml
+++ b/.github/workflows/scorecards-head.yml
@@ -69,7 +69,7 @@ jobs:
   report-failure:
     needs: scorecard-head
     runs-on: ubuntu-latest
-    if: always() && needs.scorecard-head.result != 'success'
+    if: always() # && needs.scorecard-head.result != 'success'
     steps:
       - name: "Report Scorecard run failure"
         env:

--- a/.github/workflows/scorecards-latest-release.yml
+++ b/.github/workflows/scorecards-latest-release.yml
@@ -70,19 +70,22 @@ jobs:
     if: always() && needs.scorecard-latest-release.result != 'success'
     steps:
       - name: "Report Scorecard run failure"
-        uses: actions-ecosystem/action-create-issue@b02a3c1d9d929a5839315bd255e40389f0dab627 #v1
-        with:
-          github_token: ${{ secrets.SCORECARD_READ_TOKEN }}
-          title: "Failing e2e tests - scorecard-latest-release on ${{ github.repository }}"
-          body: |
-            Matrix: ${{ toJSON(matrix) }}
+        env:
+          ISSUE_BODY: |
             Repo: https://github.com/${{ github.repository }}/tree/${{ github.ref_name }}
             Run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
             Workflow name: ${{ github.workflow }}
             Workflow file: https://github.com/${{ github.repository }}/tree/main/.github/workflows/scorecards-latest-release.yml
             Trigger: ${{ github.event_name }}
             Branch: ${{ github.ref_name }}
-          repo: "ossf/scorecard-action"
-          labels: |
-            e2e
-            automated-tests
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{ secrets.SCORECARD_READ_TOKEN }}
+          script: |
+            github.rest.issues.create({
+              owner: "ossf",
+              repo: "scorecard-action",
+              title: "Failing e2e tests - scorecard-latest-release on ${{ github.repository }}",
+              body: process.env.ISSUE_BODY,
+              labels: ["e2e", "automated-tests"]
+            });

--- a/.github/workflows/scorecards-latest-release.yml
+++ b/.github/workflows/scorecards-latest-release.yml
@@ -67,7 +67,7 @@ jobs:
   report-failure:
     needs: scorecard-latest-release
     runs-on: ubuntu-latest
-    if: always() && needs.scorecard-latest-release.result != 'success'
+    if: always() # && needs.scorecard-latest-release.result != 'success'
     steps:
       - name: "Report Scorecard run failure"
         env:


### PR DESCRIPTION
The old action hasn't been updated in years and uses an old version of node.
Additionally, the "Matrix" field was deleted since it was always "null" (because the reporting job doesn't use a matrix).

Always create an issue for testing purposes. This will be reverted once the script is tested.
   